### PR TITLE
Add build to generate a CSS only with semantic colors variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 out.css
+vars.css
 out.html
 build.js
 *.swp

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const DEFAULT_CONFIG = require('./config')
 
 const generateDocs = require('./docs')
 const generate = require('./lib/generate')
+const variables = require('./lib/variables')
 const assembleCss = require('./lib/assemble-css')
 
 const DEFAULT_OPTIONS = {
@@ -45,6 +46,12 @@ module.exports = config => {
     const docs = generateDocs(_config, { modules, min: css.css })
 
     return docs
+  }
+
+  generator.variables = async () => {
+    const cssVariables = await variables(config)
+
+    return cssVariables
   }
 
   function generator () {}

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -1,0 +1,5 @@
+const semanticColors = require('./semantic-color')
+
+module.exports = (config) => {
+  return semanticColors(config.semanticColors).variables()
+}

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,13 @@ const generate = async () => {
   const out1 = await tachy.generate({ minify: true })
   fs.writeFileSync('tachyons.min.css', out1)
 
+  // Generate a CSS only with semantic colors variables
+  const out2 = await tachy.variables()
+  fs.writeFileSync('tachyons-colors-vars.css', out2)
+
   // Keep colors as CSS variables
-  const out2 = await tachy.generate({ compileVars: false })
-  fs.writeFileSync('tachyons-with-vars.css', out2)
+  const out3 = await tachy.generate({ compileVars: false })
+  fs.writeFileSync('tachyons-with-vars.css', out3)
 
   // Generate docs website
   const docs = await tachy.docs()


### PR DESCRIPTION
Decided to build a separate module `lib/variables.js`, so we can add others vars to the output if we want.

Then would be possible to do something like:

```css
@import url('~vtex-tachyons/vars.css');

.foo {
  color: var(--c-action-primary);
}
```

Example of what was generated:

```css
:root {
  --b-action-primary: #1346d8;
  --b-action-secondary: #eef3f7;
  --b-emphasis: #f71963;
  --b-disabled: #e3e4e6;
  --b-success: #8bc34a;
  --b-success--faded: #eafce3;
  --b-danger: #ff4c4c;
  --b-danger--faded: #ffe6e6;
  --b-warning: #ffb100;
  --b-warning--faded: #fff6e0;
  --b-muted-1: #727273;
  --b-muted-2: #979899;
  --b-muted-3: #cacbcc;
  --b-muted-4: #e3e4e6;
  --b-muted-5: #f2f4f5;
  --hover-b-action-primary: #0c389f;
  --hover-b-action-secondary: #dbe9fd;
  --hover-b-emphasis: #dd1659;
  --hover-b-success: #8bc34a;
  --hover-b-success--faded: #eafce3;
  --hover-b-danger: #e13232;
  --hover-b-danger--faded: #ffe6e6;
  --hover-b-warning: #ffb100;
  --hover-b-warning--faded: #fff6e0;
  --hover-b-muted-1: #727273;
  --hover-b-muted-2: #979899;
  --hover-b-muted-3: #cacbcc;
  --hover-b-muted-4: #e3e4e6;
  --hover-b-muted-5: #f2f4f5;
  --active-b-action-primary: #0c389f;
  --active-b-action-secondary: #dbe9fd;
  --active-b-emphasis: #dd1659;
  --active-b-success: #8bc34a;
  --active-b-success--faded: #eafce3;
  --active-b-danger: #ff4c4c;
  --active-b-danger--faded: #ffe6e6;
  --active-b-warning: #ffb100;
  --active-b-warning--faded: #fff6e0;
  --active-b-muted-1: #727273;
  --active-b-muted-2: #979899;
  --active-b-muted-3: #cacbcc;
  --active-b-muted-4: #e3e4e6;
  --active-b-muted-5: #f2f4f5;
  --bg-base: #ffffff;
  --bg-base--inverted: #3f3f40;
  --bg-action-primary: #134cd8;
  --bg-action-secondary: #eef3f7;
  --bg-emphasis: #f71963;
  --bg-disabled: #e3e4e6;
  --bg-success: #8bc34a;
  --bg-success--faded: #eafce3;
  --bg-danger: #ff4c4c;
  --bg-danger--faded: #ffe6e6;
  --bg-warning: #ffb100;
  --bg-warning--faded: #fff6e0;
  --bg-muted-1: #727273;
  --bg-muted-2: #979899;
  --bg-muted-3: #cacbcc;
  --bg-muted-4: #e3e4e6;
  --bg-muted-5: #f2f4f5;
  --hover-bg-action-primary: #0c389f;
  --hover-bg-action-secondary: #dbe9fd;
  --hover-bg-emphasis: #dd1659;
  --hover-bg-success: #8bc34a;
  --hover-bg-success--faded: #eafce3;
  --hover-bg-danger: #e13232;
  --hover-bg-danger--faded: #ffe6e6;
  --hover-bg-warning: #ffb100;
  --hover-bg-warning--faded: #fff6e0;
  --hover-bg-muted-1: #727273;
  --hover-bg-muted-2: #979899;
  --hover-bg-muted-3: #cacbcc;
  --hover-bg-muted-4: #e3e4e6;
  --hover-bg-muted-5: #f2f4f5;
  --active-bg-action-primary: #0c389f;
  --active-bg-action-secondary: #dbe9fd;
  --active-bg-emphasis: #dd1659;
  --active-bg-success: #8bc34a;
  --active-bg-success--faded: #eafce3;
  --active-bg-danger: #ff4c4c;
  --active-bg-danger--faded: #ffe6e6;
  --active-bg-warning: #ffb100;
  --active-bg-warning--faded: #fff6e0;
  --active-bg-muted-1: #727273;
  --active-bg-muted-2: #979899;
  --active-bg-muted-3: #cacbcc;
  --active-bg-muted-4: #e3e4e6;
  --active-bg-muted-5: #f2f4f5;
  --c-action-primary: #134cd8;
  --c-action-secondary: #eef3f7;
  --c-link: #134cd8;
  --c-emphasis: #f71963;
  --c-disabled: #979899;
  --c-success: #8bc34a;
  --c-success--faded: #eafce3;
  --c-danger: #ff4c4c;
  --c-danger--faded: #ffe6e6;
  --c-warning: #ffb100;
  --c-warning--faded: #fff6e0;
  --c-muted-1: #727273;
  --c-muted-2: #979899;
  --c-muted-3: #cacbcc;
  --c-muted-4: #e3e4e6;
  --c-muted-5: #f2f4f5;
  --hover-c-action-primary: #0c389f;
  --hover-c-action-secondary: #dbe9fd;
  --hover-c-link: #0c389f;
  --hover-c-emphasis: #dd1659;
  --hover-c-success: #8bc34a;
  --hover-c-success--faded: #eafce3;
  --hover-c-danger: #ff4c4c;
  --hover-c-danger--faded: #ffe6e6;
  --hover-c-warning: #ffb100;
  --hover-c-warning--faded: #fff6e0;
  --active-c-link: #0c389f;
  --active-c-emphasis: #dd1659;
  --active-c-success: #8bc34a;
  --active-c-success--faded: #eafce3;
  --active-c-danger: #ff4c4c;
  --active-c-danger--faded: #ffe6e6;
  --active-c-warning: #ffb100;
  --active-c-warning--faded: #fff6e0;
  --visited-c-link: #0c389f;
  --c-on-base: #3f3f40;
  --c-on-base--inverted: #ffffff;
  --c-on-action-primary: #ffffff;
  --c-on-action-secondary: #134cd8;
  --c-on-emphasis: #ffffff;
  --c-on-disabled: #979899;
  --c-on-success: #ffffff;
  --c-on-success--faded: #3f3f40;
  --c-on-danger: #ffffff;
  --c-on-danger--faded: #3f3f40;
  --c-on-warning: #ffffff;
  --c-on-warning--faded: #1a1a1a;
  --c-on-muted-1: #ffffff;
  --c-on-muted-2: #ffffff;
  --c-on-muted-3: #3f3f40;
  --c-on-muted-4: #3f3f40;
  --c-on-muted-5: #3f3f40;
  --hover-c-on-action-primary: #ffffff;
  --hover-c-on-action-secondary: #134cd8;
  --hover-c-on-emphasis: #ffffff;
  --hover-c-on-success: #ffffff;
  --hover-c-on-success--faded: #3f3f40;
  --hover-c-on-danger: #ffffff;
  --hover-c-on-danger--faded: #3f3f40;
  --hover-c-on-warning: #ffffff;
  --hover-c-on-warning--faded: #1a1a1a;
  --active-c-on-action-primary: #ffffff;
  --active-c-on-action-secondary: #134cd8;
  --active-c-on-emphasis: #ffffff;
  --active-c-on-success: #ffffff;
  --active-c-on-success--faded: #3f3f40;
  --active-c-on-danger: #ffffff;
  --active-c-on-danger--faded: #3f3f40;
  --active-c-on-warning: #ffffff;
  --active-c-on-warning--faded: #1a1a1a;
}
```

